### PR TITLE
Improve feedback for invalid redirect URI

### DIFF
--- a/octoprint_googledrivebackup/static/js/googledrivebackup.js
+++ b/octoprint_googledrivebackup/static/js/googledrivebackup.js
@@ -6,12 +6,13 @@
  */
 const redirectHost = `https://jneilliii.github.io`;
 const redirectUri = `${redirectHost}/OctoPrint-GoogleDriveBackup/`;
+const redirectStep = '15'
 
 const isCorrectRedirectUri = (setting) => setting === redirectUri;
 
 const getRedirectUriFeedback = (setting) => {
     const linkText =
-        '<a target="_blank" href="https://github.com/jneilliii/OctoPrint-GoogleDriveBackup#create-a-google-oauth-app">step 13</a>.';
+        `<a target="_blank" href="https://github.com/jneilliii/OctoPrint-GoogleDriveBackup#create-a-google-oauth-app">step ${15}</a>.`;
     if (setting) {
         if (!setting.startsWith(redirectHost)) {
             return `Please use the host '${redirectHost}' for Authorized Redirect URI as specified in ${linkText}`;
@@ -19,7 +20,7 @@ const getRedirectUriFeedback = (setting) => {
             return `Make sure the Authorized Redirect URI ends with a trailing slash as specified in ${linkText}`;
         }
     }
-    return `Missing Authorized Redirect URI "${redirectUri}" in <a target="_blank" href="https://github.com/jneilliii/OctoPrint-GoogleDriveBackup#create-a-google-oauth-app">step 13</a>.`;
+    return `Missing Authorized Redirect URI "${redirectUri}" in ${linkText}`;
 };
 
 $(function() {

--- a/octoprint_googledrivebackup/static/js/googledrivebackup.js
+++ b/octoprint_googledrivebackup/static/js/googledrivebackup.js
@@ -9,6 +9,19 @@ const redirectUri = `${redirectHost}/OctoPrint-GoogleDriveBackup/`;
 
 const isCorrectRedirectUri = (setting) => setting === redirectUri;
 
+const getRedirectUriFeedback = (setting) => {
+    const linkText =
+        '<a target="_blank" href="https://github.com/jneilliii/OctoPrint-GoogleDriveBackup#create-a-google-oauth-app">step 13</a>.';
+    if (setting) {
+        if (!setting.startsWith(redirectHost)) {
+            return `Please use the host '${redirectHost}' for Authorized Redirect URI as specified in ${linkText}`;
+        } else if (!setting.endsWith("/")) {
+            return `Make sure the Authorized Redirect URI ends with a trailing slash as specified in ${linkText}`;
+        }
+    }
+    return `Missing Authorized Redirect URI "${redirectUri}" in <a target="_blank" href="https://github.com/jneilliii/OctoPrint-GoogleDriveBackup#create-a-google-oauth-app">step 13</a>.`;
+};
+
 $(function() {
     function GoogledrivebackupViewModel(parameters) {
         var self = this;
@@ -76,7 +89,7 @@ $(function() {
                     self.authorizing(false);
                     return
 				} else if(!isCorrectRedirectUri(json_data["web"]["redirect_uris"][0])) {
-                    self.client_secret_alert('Missing Authorized Redirect URI "https://jneilliii.github.io/OctoPrint-GoogleDriveBackup/" in <a target="_blank" href="https://github.com/jneilliii/OctoPrint-GoogleDriveBackup#create-a-google-oauth-app">step 13</a>.');
+                    self.client_secret_alert(getRedirectUriFeedback(json_data["web"]["redirect_uris"][0]));
                     self.authorizing(false);
                     return
                 } else {

--- a/octoprint_googledrivebackup/static/js/googledrivebackup.js
+++ b/octoprint_googledrivebackup/static/js/googledrivebackup.js
@@ -60,6 +60,11 @@ $(function() {
 
         $("#googledrivebackup_cert_file").fileupload(certFileuploadOptions);
 
+        $("#googledrivebackup_cert_file").change(() => {
+            // Change in file selection, so we don't know if invalid or not yet
+            self.client_secret_alert('');
+        })
+
         self.onBeforeBinding = function() {
 			self.cert_saved(self.settingsViewModel.settings.plugins.googledrivebackup.cert_saved());
 			self.cert_authorized(self.settingsViewModel.settings.plugins.googledrivebackup.cert_authorized());

--- a/octoprint_googledrivebackup/static/js/googledrivebackup.js
+++ b/octoprint_googledrivebackup/static/js/googledrivebackup.js
@@ -4,6 +4,11 @@
  * Author: jneilliii
  * License: MIT
  */
+const redirectHost = `https://jneilliii.github.io`;
+const redirectUri = `${redirectHost}/OctoPrint-GoogleDriveBackup/`;
+
+const isCorrectRedirectUri = (setting) => setting === redirectUri;
+
 $(function() {
     function GoogledrivebackupViewModel(parameters) {
         var self = this;
@@ -70,7 +75,7 @@ $(function() {
 					self.client_secret_alert('Incorrect oAuth Credential type selected in <a target="_blank" href="https://github.com/jneilliii/OctoPrint-GoogleDriveBackup#create-a-google-oauth-app">step 13</a>.');
                     self.authorizing(false);
                     return
-				} else if(json_data["web"]["redirect_uris"][0] !== 'https://jneilliii.github.io/OctoPrint-GoogleDriveBackup/') {
+				} else if(!isCorrectRedirectUri(json_data["web"]["redirect_uris"][0])) {
                     self.client_secret_alert('Missing Authorized Redirect URI "https://jneilliii.github.io/OctoPrint-GoogleDriveBackup/" in <a target="_blank" href="https://github.com/jneilliii/OctoPrint-GoogleDriveBackup#create-a-google-oauth-app">step 13</a>.');
                     self.authorizing(false);
                     return


### PR DESCRIPTION
A few small changes to improve error feedback when the generated JSON uses the wrong redirect URI:
- Call out the 'missing slash' case explicitly (#38 )
- Call out incorrect host (I incorrectly used the repo instead of the GH pages link at first, and spent quite some time scratching my head about why it wouldn't work...this turned out to be the issue)
- Clear the error on a new upload, so that the user knows the new file has been uploaded successfully

An example of the newly handled 'incorrect host' case:

![image](https://user-images.githubusercontent.com/2937540/210141351-f66ab4db-72a1-4058-94e6-525642c368c3.png)


I'm relying on some ES 6+ syntax for these changes, as I already saw one place in the code using `let` (and saw a thread somewhere, whereby this syntax was generally approved for use in OctoPrint core).

I would be open to adding tests as well, but most (FE) test tools I know of these days have so many dependencies that they require introducing something like `npm` or `yarn`. Open to help add these or continue with ES 6 refactors, if that's of interest - just let me know (for this or other OctoPrint stuff).

Otherwise let me know if you have questions or anything needs adjusting.

Thanks!